### PR TITLE
Add script for Megatron docker

### DIFF
--- a/train/v2.1/mi300x/run-megatron.sh
+++ b/train/v2.1/mi300x/run-megatron.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME=megatron-lm
+IMAGE="rocm/megatron-lm:latest"
+
+TRAIN_DIR="$HOME/shisa-v2/train/v2.1/mi300x"
+HF_CACHE_DIR="$HOME/.cache/huggingface"
+
+if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "Attaching to running container ${CONTAINER_NAME}..."
+    exec docker exec -it ${CONTAINER_NAME} bash
+else
+    echo "Starting new container ${CONTAINER_NAME} from ${IMAGE}..."
+    exec docker run --gpus all --rm -it \
+        --name ${CONTAINER_NAME} \
+        --ipc=host --network=host --privileged \
+        --device=/dev/kfd --device=/dev/dri --device=/dev/mem \
+        --cap-add CAP_SYS_ADMIN --cap-add SYS_PTRACE \
+        --group-add render \
+        --security-opt seccomp=unconfined \
+        --mount type=bind,src="${TRAIN_DIR}",target=/workspace/train \
+        --mount type=bind,src="${HF_CACHE_DIR}",target=/root/.cache/huggingface \
+        ${IMAGE} bash
+fi
+


### PR DESCRIPTION
## Summary
- add `run-megatron.sh` helper under `train/v2.1/mi300x`
- script launches the `rocm/megatron-lm` container, mounting training and Hugging Face cache directories
- reattach to the container if it is already running

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68826f929744833289977610358014b2