### PR TITLE
Add MegaBlocks/Megatron helper scripts

### DIFF
--- a/train/v2.1/mi300x/megatron-convert-model.sh
+++ b/train/v2.1/mi300x/megatron-convert-model.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <hf_model_dir> <output_dir>" >&2
+    exit 1
+fi
+
+HF_MODEL=$1
+OUT_DIR=$2
+MEGATRON_DIR=${MEGATRON_DIR:-/workspace/Megatron-LM}
+
+python $MEGATRON_DIR/tools/checkpoint/convert_hf_checkpoint.py \
+       --input-dir "$HF_MODEL" \
+       --output-dir "$OUT_DIR"

--- a/train/v2.1/mi300x/megatron-dataset-dpo.py
+++ b/train/v2.1/mi300x/megatron-dataset-dpo.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Convert OpenRLHF DPO dataset to Megatron-LM binary format."""
+import argparse, tempfile, subprocess
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+p = argparse.ArgumentParser()
+p.add_argument("--input", required=True)
+p.add_argument("--tokenizer", required=True)
+p.add_argument("--tokenizer-json", required=True)
+p.add_argument("--output-prefix", required=True)
+p.add_argument("--workers", type=int, default=8)
+args = p.parse_args()
+
+tok = AutoTokenizer.from_pretrained(args.tokenizer)
+
+ds = load_dataset("json", data_files=args.input, split="train")
+
+def fmt(ex):
+    prmpt = ex["chosen"][:-1]
+    prompt = tok.apply_chat_template(prmpt, tokenize=False, add_generation_prompt=False)
+    chosen = ex["chosen"][-1]["content"]
+    rejected = ex["rejected"][-1]["content"]
+    return {"text": prompt + "\n### CHOSEN:\n" + chosen + "\n### REJECTED:\n" + rejected}
+
+ds = ds.map(fmt, remove_columns=ds.column_names)
+
+with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+    for t in ds["text"]:
+        tmp.write(t + "\n")
+    tmp_path = tmp.name
+
+subprocess.check_call([
+    "python", "tools/preprocess_data.py",
+    "--input", tmp_path,
+    "--output-prefix", args.output_prefix,
+    "--vocab-file", args.tokenizer_json,
+    "--tokenizer-type", "HuggingFaceTokenizer",
+    "--dataset-impl", "mmap",
+    "--workers", str(args.workers),
+    "--append-eod",
+])

--- a/train/v2.1/mi300x/megatron-dataset-sft.py
+++ b/train/v2.1/mi300x/megatron-dataset-sft.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Convert OpenRLHF SFT dataset to Megatron-LM binary format."""
+import argparse, tempfile, subprocess, json
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+p = argparse.ArgumentParser()
+p.add_argument("--input", required=True)
+p.add_argument("--tokenizer", required=True, help="Tokenizer name or path")
+p.add_argument("--tokenizer-json", required=True, help="Path to tokenizer.json")
+p.add_argument("--output-prefix", required=True)
+p.add_argument("--workers", type=int, default=8)
+args = p.parse_args()
+
+tok = AutoTokenizer.from_pretrained(args.tokenizer)
+
+ds = load_dataset("json", data_files=args.input, split="train")
+
+def fmt(ex):
+    text = tok.apply_chat_template(ex["conversations"], tokenize=False, add_generation_prompt=False)
+    return {"text": text.replace("\n", " ")}
+
+ds = ds.map(fmt, remove_columns=ds.column_names)
+
+with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+    for t in ds["text"]:
+        tmp.write(t + "\n")
+    tmp_path = tmp.name
+
+subprocess.check_call([
+    "python", "tools/preprocess_data.py",
+    "--input", tmp_path,
+    "--output-prefix", args.output_prefix,
+    "--vocab-file", args.tokenizer_json,
+    "--tokenizer-type", "HuggingFaceTokenizer",
+    "--dataset-impl", "mmap",
+    "--workers", str(args.workers),
+    "--append-eod",
+])

--- a/train/v2.1/mi300x/megatron-train-sft.sh
+++ b/train/v2.1/mi300x/megatron-train-sft.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export WANDB_ENTITY=augmxnt
+export WANDB_PROJECT="shisa-v2.1"
+export HF_HUB_ENABLE_HF_TRANSFER=1
+export NCCL_ASYNC_ERROR_HANDLING=1
+
+ORIG_MODEL=${ORIG_MODEL:-"qwen/Qwen3-30B-A3B"}
+SFT_CKPT=${SFT_CKPT:-"054-qwen3moe-megatron"}
+DATA_PREFIX=${DATA_PREFIX:-"/workspace/data/sft_dataset_text_document"}
+TOKENIZER_JSON=${TOKENIZER_JSON:-"/workspace/tokenizer/qwen3-30b/tokenizer.json"}
+
+export DATA_PATH="$DATA_PREFIX"
+export LOAD_PATH="$ORIG_MODEL"
+export SAVE_PATH="$SFT_CKPT"
+
+export TEE_OUTPUT=1
+export MBS=2
+export GBS=128
+export TP_SIZE=1
+export PP_SIZE=1
+export EP_SIZE=8
+export ETP_SIZE=1
+export AC=full
+export PR=bf16
+export SEQ_LENGTH=8192
+
+cd /workspace/Megatron-LM
+bash examples/llama/train_llama3.sh

--- a/train/v2.1/mi300x/setup-megablocks.sh
+++ b/train/v2.1/mi300x/setup-megablocks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install MegaBlocks ROCm fork inside the Megatron-LM container.
+# Run this script inside the rocm/megatron-lm Docker image.
+
+MEGABLOCKS_DIR=${MEGABLOCKS_DIR:-$HOME/megablocks}
+
+if [ ! -d "$MEGABLOCKS_DIR" ]; then
+    git clone https://github.com/ROCm/megablocks.git "$MEGABLOCKS_DIR"
+fi
+
+pip install -U pip
+pip install "$MEGABLOCKS_DIR"


### PR DESCRIPTION
## Summary
- add setup-megablocks.sh for installing ROCm MegaBlocks
- add megatron-convert-model.sh wrapper for HF->Megatron
- add megatron-dataset-sft.py and megatron-dataset-dpo.py to build datasets
- add megatron-train-sft.sh showing example training launch

## Testing
- `python -m py_compile train/v2.1/mi300x/megatron-dataset-sft.py train/v2.1/mi300x/megatron-dataset-dpo.py`

------
https://chatgpt.com/codex/tasks/task_e_688270a57974833297b115b6c7e7e475